### PR TITLE
feat: error handling & tracing improvements (v0.1.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 
 
+## [0.1.11] - 2026-05-31
+
+### Added
+- `LiteToolLLMError` base exception; every library error now inherits from it, so callers can `except LiteToolLLMError` to catch any error in one place
+- `FunctionExecutionError.tool_call` attribute, exposing the raw model tool-call alongside `function_name` and `details`
+- `UnifiedResponse.usage` and `UnifiedResponse.cost` fields, populated (best-effort) from the final model response for token/cost observability
+- `get_usage_and_cost()` helper in `utils`
+
+### Changed
+- `FunctionExecutionError.function_name` now holds the actual tool name string (previously it received the raw tool-call object)
+- Async tool failures now raise `FunctionExecutionError` (consistent with the sync path) instead of letting the raw exception propagate; the original error is preserved as `__cause__`
+- Added debug logging to the async tool-call path (previously only the sync path logged) and a warning log when response validation fails
+- `RecursionDepthExceedError` is deprecated in favour of `MaxRecursionError` (kept as a subclass of `LiteToolLLMError` for backward compatibility)
+- Async tool execution computes the function mapping once per turn instead of once per tool call
+
 ## [0.1.10] - 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `FunctionExecutionError.tool_call` attribute, exposing the raw model tool-call alongside `function_name` and `details`
 - `UnifiedResponse.usage` and `UnifiedResponse.cost` fields, populated (best-effort) from the final model response for token/cost observability
 - `get_usage_and_cost()` helper in `utils`
+- README: "Observability & Tracing" section documenting the `usage`/`cost` fields and the LiteLLM `success_callback` + `metadata` pattern for Langfuse/OpenTelemetry tracing
 
 ### Changed
 - `FunctionExecutionError.function_name` now holds the actual tool name string (previously it received the raw tool-call object)

--- a/litetoolllm/core.py
+++ b/litetoolllm/core.py
@@ -1,4 +1,5 @@
 # litetoolllm/core.py
+import logging
 from typing import Type, Any, List, Optional, Callable
 from pydantic import BaseModel
 from litellm import completion, acompletion
@@ -6,14 +7,21 @@ from .errors import StructuredValidationError
 from .utils import (
     validate_model_capabilities,
     get_content_from_raw_response,
+    get_usage_and_cost,
     _handle_tool_call_loop,
     _handle_tool_call_loop_async,
     convert_tools_to_api_format,
 )
 
+logger = logging.getLogger(__name__)
+
 class UnifiedResponse(BaseModel):
     content: Optional[Any] = None
     messages: List[Any] = []
+    # Observability fields populated from the final model response.
+    # Default to None so existing callers are unaffected.
+    usage: Optional[Any] = None
+    cost: Optional[float] = None
 
 def structured_completion(*, model: str, messages: List[dict],
                           response_model: Optional[Type[BaseModel]] = None,
@@ -50,11 +58,15 @@ def structured_completion(*, model: str, messages: List[dict],
         else:
             parsed = response_content
     except Exception as e:
+        logger.warning("Failed to validate response against %s: %s", response_model, e)
         raise StructuredValidationError("Failed to validate response", retry_context=raw_response) from e
 
+    usage, cost = get_usage_and_cost(raw_response)
     return UnifiedResponse(
         content=parsed,
-        messages=messages
+        messages=messages,
+        usage=usage,
+        cost=cost,
     )
 
 async def astructured_completion(*, model: str, messages: List[dict],
@@ -97,9 +109,14 @@ async def astructured_completion(*, model: str, messages: List[dict],
         else:
             parsed = response_content
     except Exception as e:
+        logger.warning("Failed to validate response against %s: %s",
+                       response_model or post_format_response_model, e)
         raise StructuredValidationError("Failed to validate response", retry_context=raw_response) from e
 
+    usage, cost = get_usage_and_cost(raw_response)
     return UnifiedResponse(
         content=parsed,
-        messages=messages
+        messages=messages,
+        usage=usage,
+        cost=cost,
     )

--- a/litetoolllm/errors.py
+++ b/litetoolllm/errors.py
@@ -1,20 +1,59 @@
 # litetoolllm/errors.py
-class ModelCapabilityError(Exception):
+
+
+class LiteToolLLMError(Exception):
+    """Base class for every error raised by litetoolllm.
+
+    Catch this to handle any library error in one place:
+
+        try:
+            structured_completion(...)
+        except LiteToolLLMError:
+            ...
+    """
     pass
 
 
-class MaxRecursionError(Exception):
+class ModelCapabilityError(LiteToolLLMError):
+    """The requested model does not support a required capability
+    (JSON/structured output or tool calling)."""
     pass
-class StructuredValidationError(Exception):
+
+
+class MaxRecursionError(LiteToolLLMError):
+    """The tool-calling loop hit ``max_recursion`` without producing a
+    final answer."""
+    pass
+
+
+class StructuredValidationError(LiteToolLLMError):
+    """The model response could not be validated against ``response_model``.
+
+    ``retry_context`` holds the raw model response that failed validation.
+    """
     def __init__(self, message, retry_context=None):
         super().__init__(message)
         self.retry_context = retry_context
 
-class FunctionExecutionError(Exception):
-    def __init__(self, function_name, details):
+
+class FunctionExecutionError(LiteToolLLMError):
+    """A tool raised while being executed during a tool call.
+
+    Attributes:
+        function_name: Name of the tool that failed.
+        details: String form of the underlying error.
+        tool_call: The raw tool-call object from the model (if available).
+
+    The original exception is preserved as ``__cause__`` (``raise ... from e``).
+    """
+    def __init__(self, function_name, details, tool_call=None):
         super().__init__(f"Error in {function_name}: {details}")
         self.function_name = function_name
         self.details = details
+        self.tool_call = tool_call
 
-class RecursionDepthExceedError(Exception):
+
+class RecursionDepthExceedError(LiteToolLLMError):
+    """Deprecated: kept for backward compatibility; not raised internally.
+    Use :class:`MaxRecursionError` instead."""
     pass

--- a/litetoolllm/utils.py
+++ b/litetoolllm/utils.py
@@ -57,6 +57,22 @@ def validate_model_capabilities(model, response_model, tools):
 def get_content_from_raw_response(raw_response):
     return raw_response.get('choices', [{}])[0].get('message', {}).get('content', '{}')
 
+def get_usage_and_cost(raw_response):
+    """Best-effort extraction of token usage and dollar cost from a model
+    response. Returns ``(usage, cost)`` where either may be ``None`` if the
+    information is unavailable (e.g. an unknown/custom model)."""
+    usage = None
+    cost = None
+    try:
+        usage = raw_response.get('usage')
+    except Exception:
+        logger.debug("Could not read usage from response", exc_info=True)
+    try:
+        cost = litellm.completion_cost(completion_response=raw_response)
+    except Exception:
+        logger.debug("Could not compute completion cost", exc_info=True)
+    return usage, cost
+
 def get_tool_calls(raw_response):
     return raw_response.get('choices', [{}])[0].get('message', {}).get('tool_calls', None)
 
@@ -112,7 +128,8 @@ def handle_tool_calls(raw_response, tools, metadata):
                     }
                 )
             except Exception as e:
-                raise FunctionExecutionError(tool_call, str(e)) from e
+                name = getattr(getattr(tool_call, "function", None), "name", "unknown")
+                raise FunctionExecutionError(name, str(e), tool_call=tool_call) from e
         return new_messages
 
 def _handle_tool_call_loop(kwargs, max_recursion, messages, model, raw_response, response_model,
@@ -138,28 +155,34 @@ async def handle_tool_calls_async(raw_response, tools, metadata):
     if not tool_calls:
         return []
 
-    async def execute_tool_call(tool_call, tools):
-        function_mapping = get_function_mapping(tools)
-        function_name, function_to_call, function_args = _extract_function_details(tool_call, function_mapping)
+    function_mapping = get_function_mapping(tools)
 
-        # Always remove metadata from LLM-provided args (the LLM may echo it back
-        # because it's in the schema), then re-inject our own value if the function wants it.
-        function_args.pop('metadata', None)
-        sig = inspect.signature(function_to_call)
-        accepts_metadata = 'metadata' in sig.parameters
-        if inspect.iscoroutinefunction(function_to_call):
-            result = await function_to_call(**function_args, metadata=metadata) if accepts_metadata else await function_to_call(**function_args)
-        else:
-            result = function_to_call(**function_args, metadata=metadata) if accepts_metadata else function_to_call(**function_args)
-        
-        return {
-            "role": "tool",
-            "tool_call_id": tool_call.get("id"),
-            "content": json.dumps(result) if isinstance(result, dict) else result,
-            "name": function_name
-        }
+    async def execute_tool_call(tool_call):
+        try:
+            logger.debug("Executing tool call: %s", tool_call)
+            function_name, function_to_call, function_args = _extract_function_details(tool_call, function_mapping)
 
-    tasks = [execute_tool_call(tool_call, tools) for tool_call in tool_calls]
+            # Always remove metadata from LLM-provided args (the LLM may echo it back
+            # because it's in the schema), then re-inject our own value if the function wants it.
+            function_args.pop('metadata', None)
+            sig = inspect.signature(function_to_call)
+            accepts_metadata = 'metadata' in sig.parameters
+            if inspect.iscoroutinefunction(function_to_call):
+                result = await function_to_call(**function_args, metadata=metadata) if accepts_metadata else await function_to_call(**function_args)
+            else:
+                result = function_to_call(**function_args, metadata=metadata) if accepts_metadata else function_to_call(**function_args)
+
+            return {
+                "role": "tool",
+                "tool_call_id": tool_call.get("id"),
+                "content": json.dumps(result) if isinstance(result, dict) else result,
+                "name": function_name
+            }
+        except Exception as e:
+            name = getattr(getattr(tool_call, "function", None), "name", "unknown")
+            raise FunctionExecutionError(name, str(e), tool_call=tool_call) from e
+
+    tasks = [execute_tool_call(tool_call) for tool_call in tool_calls]
     responses = await asyncio.gather(*tasks)
     messages = [raw_response.choices[0].message.model_dump(), *responses]
 

--- a/readme.md
+++ b/readme.md
@@ -178,17 +178,64 @@ All completion functions return a `UnifiedResponse` object:
 |-------|------|-------------|
 | `content` | `BaseModel \| str \| None` | The parsed response — a Pydantic model instance if `response_model` was provided, otherwise a plain string |
 | `messages` | `List[dict]` | The full conversation history including tool calls and results, ready to pass back as `messages` for multi-turn conversations |
+| `usage` | `Usage \| None` | Token usage from the final model response (best-effort; `None` if unavailable) |
+| `cost` | `float \| None` | Estimated dollar cost of the final response (best-effort; `None` for unknown/custom models) |
 
 ## Error Handling
 
+Every exception inherits from `LiteToolLLMError`, so you can catch them all in one place:
+
+```python
+from litetoolllm.errors import LiteToolLLMError
+
+try:
+    structured_completion(...)
+except LiteToolLLMError as e:
+    ...  # any litetoolllm error
+```
+
 | Exception | When raised |
 |-----------|-------------|
+| `LiteToolLLMError` | Base class for all errors below |
 | `ModelCapabilityError` | Model doesn't support JSON output or tool calling |
 | `MaxRecursionError` | Tool call chain exceeds `max_recursion` limit |
 | `StructuredValidationError` | LLM output couldn't be parsed into `response_model` |
-| `FunctionExecutionError` | A tool function raised an exception at runtime |
+| `FunctionExecutionError` | A tool function raised at runtime (exposes `.function_name`, `.details`, `.tool_call`; original error in `__cause__`) |
 
 Import from `litetoolllm.errors`.
+
+## Observability & Tracing
+
+Each `UnifiedResponse` carries the final response's `usage` and `cost` for lightweight tracking:
+
+```python
+result = structured_completion(model="gpt-4o", messages=messages, response_model=MyModel)
+print(result.usage)  # token counts
+print(result.cost)   # estimated $ cost
+```
+
+For full tracing, litetoolllm calls LiteLLM directly, so LiteLLM's built-in
+integrations (Langfuse, OpenTelemetry, etc.) work without any wrapper-specific
+setup. Register the callback globally once:
+
+```python
+import litellm
+litellm.success_callback = ["langfuse"]   # set LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY env vars
+```
+
+Anything you pass as `metadata=` is forwarded straight to LiteLLM, which Langfuse
+uses for trace correlation (`trace_id`, `session_id`, `tags`, …):
+
+```python
+structured_completion(
+    model="gpt-4o",
+    messages=messages,
+    response_model=MyModel,
+    metadata={"trace_id": "abc-123", "session_id": "user-42", "tags": ["prod"]},
+)
+```
+
+See the [LiteLLM logging docs](https://docs.litellm.ai/docs/observability/langfuse_integration) for other backends.
 
 ### API Reference
 # structured_completion()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="litetoolllm",
-    version="0.1.10",
+    version="0.1.11",
     packages=["litetoolllm"],
     py_modules=["__init__"],
     install_requires=[

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,110 @@
+# tests/test_error_handling.py
+"""Deterministic (no-API) tests for the error hierarchy and observability fields.
+
+These lock in:
+- every library error inheriting from `LiteToolLLMError`
+- `FunctionExecutionError` carrying the tool name, details and raw tool_call
+- tool failures (sync and async) being surfaced as `FunctionExecutionError`
+- `UnifiedResponse` exposing optional `usage`/`cost` fields
+- `get_usage_and_cost` degrading gracefully
+
+They run without any API key.
+"""
+import pytest
+
+from litetoolllm.core import UnifiedResponse
+from litetoolllm.errors import (
+    LiteToolLLMError,
+    ModelCapabilityError,
+    MaxRecursionError,
+    StructuredValidationError,
+    FunctionExecutionError,
+    RecursionDepthExceedError,
+)
+from litetoolllm.utils import handle_tool_calls, handle_tool_calls_async, get_usage_and_cost
+
+from test_metadata_handling import _ToolCall, _ToolCallAsync, _sync_raw, _async_raw
+
+
+# --- Exception hierarchy ----------------------------------------------------
+
+class TestExceptionHierarchy:
+    @pytest.mark.parametrize("err_cls", [
+        ModelCapabilityError,
+        MaxRecursionError,
+        StructuredValidationError,
+        FunctionExecutionError,
+        RecursionDepthExceedError,
+    ])
+    def test_all_errors_inherit_base(self, err_cls):
+        assert issubclass(err_cls, LiteToolLLMError)
+
+    def test_function_execution_error_attributes(self):
+        err = FunctionExecutionError("weather", "boom", tool_call={"id": "call_1"})
+        assert err.function_name == "weather"
+        assert err.details == "boom"
+        assert err.tool_call == {"id": "call_1"}
+        assert str(err) == "Error in weather: boom"
+
+    def test_function_execution_error_tool_call_defaults_none(self):
+        err = FunctionExecutionError("weather", "boom")
+        assert err.tool_call is None
+
+    def test_structured_validation_error_keeps_retry_context(self):
+        err = StructuredValidationError("bad", retry_context={"raw": 1})
+        assert err.retry_context == {"raw": 1}
+
+
+# --- Tool failures surface as FunctionExecutionError ------------------------
+
+class TestSyncToolFailure:
+    def test_failing_tool_raises_function_execution_error(self):
+        def weather(location: str) -> dict:
+            raise RuntimeError("upstream down")
+
+        tc = _ToolCall("call_1", "weather", '{"location": "SF"}')
+        with pytest.raises(FunctionExecutionError) as exc:
+            handle_tool_calls(raw_response=_sync_raw([tc]), tools=[weather], metadata=None)
+
+        assert exc.value.function_name == "weather"
+        assert exc.value.tool_call is tc
+        assert isinstance(exc.value.__cause__, RuntimeError)
+
+
+class TestAsyncToolFailure:
+    async def test_failing_async_tool_raises_function_execution_error(self):
+        async def weather(location: str) -> dict:
+            raise RuntimeError("upstream down")
+
+        tc = _ToolCallAsync("call_1", "weather", '{"location": "SF"}')
+        with pytest.raises(FunctionExecutionError) as exc:
+            await handle_tool_calls_async(raw_response=_async_raw([tc]), tools=[weather], metadata=None)
+
+        assert exc.value.function_name == "weather"
+        assert exc.value.tool_call is tc
+        assert isinstance(exc.value.__cause__, RuntimeError)
+
+
+# --- Observability ----------------------------------------------------------
+
+class TestUnifiedResponseObservability:
+    def test_usage_and_cost_default_to_none(self):
+        resp = UnifiedResponse(content={"ok": True}, messages=[])
+        assert resp.usage is None
+        assert resp.cost is None
+
+    def test_usage_and_cost_can_be_set(self):
+        resp = UnifiedResponse(content=None, messages=[], usage={"total_tokens": 42}, cost=0.001)
+        assert resp.usage == {"total_tokens": 42}
+        assert resp.cost == 0.001
+
+
+class TestGetUsageAndCost:
+    def test_reads_usage_and_never_raises(self):
+        usage, cost = get_usage_and_cost({"usage": {"total_tokens": 10}})
+        assert usage == {"total_tokens": 10}
+        # cost may be None (unknown/fake model) but the call must not raise.
+
+    def test_missing_usage_returns_none(self):
+        usage, cost = get_usage_and_cost({})
+        assert usage is None


### PR DESCRIPTION
## Summary
Hardens error handling and adds lightweight tracing/observability, keeping the public API backward compatible.

- **Unified exception hierarchy** — new `LiteToolLLMError` base class; every library error (`ModelCapabilityError`, `MaxRecursionError`, `StructuredValidationError`, `FunctionExecutionError`, `RecursionDepthExceedError`) now inherits it, so callers can `except LiteToolLLMError` to catch any error in one place.
- **Better `FunctionExecutionError`** — now stores the real tool **name** (`function_name`), the error `details`, and the raw `tool_call` object. Original exception preserved as `__cause__`.
- **Consistent async errors** — async tool failures now raise `FunctionExecutionError` (previously the raw exception propagated), matching the sync path.
- **Tracing** — added debug logging to the async tool-call path (sync already had it), a warning log when response validation fails, and `usage` / `cost` fields on `UnifiedResponse` (best-effort, default `None`) via a new `get_usage_and_cost()` helper.
- **Cleanup** — `RecursionDepthExceedError` deprecated in favour of `MaxRecursionError` (kept as a subclass for back-compat); async tool execution computes the function mapping once per turn.

## Backward compatibility
Fully compatible except two intentional behavior corrections:
1. `FunctionExecutionError.function_name` now holds the tool **name string** (it previously received the raw tool-call object — a latent bug). Constructor signature is unchanged (`function_name, details`) plus a new optional `tool_call=`.
2. Async tool failures now surface as `FunctionExecutionError` instead of the raw exception type. The original is still accessible via `__cause__`.

Retry/self-correction was intentionally left out of this PR.

## Test plan
- [x] `pytest tests/test_error_handling.py tests/test_metadata_handling.py` → 20 passed (no API key needed)
- [x] Full suite collects cleanly (37 tests)
- [x] Library imports verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)